### PR TITLE
deps: bump @heroicons/react v1 → v2

### DIFF
--- a/components/Alert.js
+++ b/components/Alert.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/solid'
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/solid'
 
 export default class Alert extends React.Component {
   render() {

--- a/components/Home.js
+++ b/components/Home.js
@@ -1,10 +1,10 @@
 import {
   CheckIcon,
+  HandThumbUpIcon,
   PaperClipIcon,
   QuestionMarkCircleIcon,
-  ThumbUpIcon,
   UserIcon,
-} from '@heroicons/react/solid'
+} from '@heroicons/react/24/solid'
 
 const user = {
   name: 'Whitney Francis',
@@ -18,7 +18,7 @@ const attachments = [
 ]
 const eventTypes = {
   applied: { icon: UserIcon, bgColorClass: 'bg-gray-400' },
-  advanced: { icon: ThumbUpIcon, bgColorClass: 'bg-blue-500' },
+  advanced: { icon: HandThumbUpIcon, bgColorClass: 'bg-blue-500' },
   completed: { icon: CheckIcon, bgColorClass: 'bg-green-500' },
 }
 const timeline = [

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,8 +1,8 @@
 import { Fragment } from 'react'
 import Link from 'next/link'
 import { Menu, Popover, Transition } from '@headlessui/react'
-import { SearchIcon } from '@heroicons/react/solid'
-import { BellIcon, MenuIcon, XIcon } from '@heroicons/react/outline'
+import { MagnifyingGlassIcon } from '@heroicons/react/24/solid'
+import { BellIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 
 const user = {
   name: 'Whitney Francis',
@@ -65,7 +65,7 @@ export default function Layout(props) {
                     </label>
                     <div className="relative">
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <SearchIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
+                        <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />
                       </div>
                       <input
                         id="search"
@@ -81,7 +81,7 @@ export default function Layout(props) {
                   {/* Mobile menu button */}
                   <Popover.Button className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">
                     <span className="sr-only">Open main menu</span>
-                    <MenuIcon className="block h-6 w-6" aria-hidden="true" />
+                    <Bars3Icon className="block h-6 w-6" aria-hidden="true" />
                   </Popover.Button>
                 </div>
                 <Transition.Root show={open} as={Fragment}>
@@ -129,7 +129,7 @@ export default function Layout(props) {
                               <div className="-mr-2">
                                 <Popover.Button className="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">
                                   <span className="sr-only">Close menu</span>
-                                  <XIcon className="h-6 w-6" aria-hidden="true" />
+                                  <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                                 </Popover.Button>
                               </div>
                             </div>

--- a/components/LoginWithEmail.js
+++ b/components/LoginWithEmail.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { MailIcon } from '@heroicons/react/solid'
+import { EnvelopeIcon } from '@heroicons/react/24/solid'
 import Alert from './Alert'
 
 export default class LoginWithEmail extends React.Component {
@@ -41,7 +41,7 @@ export default class LoginWithEmail extends React.Component {
                   type="submit"
                   className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                 >
-                  <MailIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
+                  <EnvelopeIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                   Send Magic Link
                 </button>
               </div>

--- a/components/LoginWithSSO.js
+++ b/components/LoginWithSSO.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import { LockClosedIcon } from '@heroicons/react/solid'
+import { LockClosedIcon } from '@heroicons/react/24/solid'
 import Alert from './Alert'
 
 export default class LoginWithSSO extends React.Component {

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -1,7 +1,7 @@
-import { CogIcon, UserCircleIcon } from '@heroicons/react/outline'
+import { Cog6ToothIcon, UserCircleIcon } from '@heroicons/react/24/outline'
 
 const subNavigation = [
-  { name: 'Admin Settings', href: '#', icon: CogIcon, current: true },
+  { name: 'Admin Settings', href: '#', icon: Cog6ToothIcon, current: true },
   { name: 'Your Profile', href: '#', icon: UserCircleIcon, current: false },
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.3.0",
-        "@heroicons/react": "^1.0.2",
-        "@workos-inc/node": "^8.13.0",
+        "@heroicons/react": "^2.2.0",
+        "@workos-inc/node": "^8.10.0",
         "eslint-config-next": "^13.4.19",
         "next": "^13.4.19",
         "postcss-import": "^14.0.2",
@@ -196,11 +196,12 @@
       }
     },
     "node_modules/@heroicons/react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
-      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": ">= 16"
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5045,9 +5046,9 @@
       }
     },
     "@heroicons/react": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
-      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.3.0",
-    "@heroicons/react": "^1.0.2",
+    "@heroicons/react": "^2.2.0",
     "@workos-inc/node": "^8.10.0",
     "eslint-config-next": "^13.4.19",
     "next": "^13.4.19",


### PR DESCRIPTION
## Summary
- Bumps `@heroicons/react` from `^1.0.2` → `^2.2.0`.
- v2 namespaced icons under size paths (`/24/solid`, `/24/outline`) and renamed several icons. Updates 6 component files for the path move plus the affected icon renames: `ThumbUpIcon→HandThumbUpIcon`, `MailIcon→EnvelopeIcon`, `MenuIcon→Bars3Icon`, `XIcon→XMarkIcon`, `SearchIcon→MagnifyingGlassIcon`, `CogIcon→Cog6ToothIcon`.
- No UX change. Same icons, same sizes, same positions.

Part of the modernization series.

## Test plan
- [x] `npm install @heroicons/react@^2.0.0` clean
- [x] `npm run build` passes
- [x] Vercel preview: tile icons (cog/user circle), nav (search, bell, mobile menu/close), email login (envelope), SSO login (lock), home timeline (thumbs-up, check, user), alerts (check/x circles), notes (paperclip, question mark) all render