### PR TITLE
fix: update footer GitHub link to current org

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -120,7 +120,7 @@ export default class extends React.Component {
       },
       {
         name: 'GitHub',
-        href: 'https://github.com/workos-inc',
+        href: 'https://github.com/workos/workos-explore',
         icon: (props) => (
           <svg fill="currentColor" viewBox="0 0 24 24" {...props}>
             <path


### PR DESCRIPTION
## Summary
- The footer's GitHub icon linked to `github.com/workos-inc`, which 404s — the org is `workos`.
- Updates the link to point at this repo (`github.com/workos/workos-explore`) so visitors can browse the demo's source directly.

One line, one file.

## Test plan
- [x] Vercel preview: footer GitHub icon resolves to a valid page