### PR TITLE
feat: show build commit SHA in footer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    NEXT_PUBLIC_COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA || '',
+  },
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -147,6 +147,19 @@ export default class extends React.Component {
           <div className="mt-8 md:mt-0 md:order-1">
             <p className="text-center text-base text-gray-400">
               &copy; {new Date().getFullYear()} WorkOS, Inc.
+              {process.env.NEXT_PUBLIC_COMMIT_SHA && (
+                <>
+                  {' · '}
+                  <a
+                    href={`https://github.com/workos/workos-explore/commit/${process.env.NEXT_PUBLIC_COMMIT_SHA}`}
+                    className="font-mono text-sm hover:text-gray-500"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {process.env.NEXT_PUBLIC_COMMIT_SHA.slice(0, 7)}
+                  </a>
+                </>
+              )}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Renders a 7-char commit SHA next to the footer copyright (e.g. `© 2026 WorkOS, Inc. · a3b289f`), linking to the GitHub commit. Lets anyone viewing the demo identify which build they're looking at.
- Adds a minimal `next.config.js` that bridges Vercel's build-time `VERCEL_GIT_COMMIT_SHA` env var into a `NEXT_PUBLIC_COMMIT_SHA` so the value inlines into the client bundle at build time.
- Local dev (no env var set) hides the SHA via conditional render — graceful fallback, no UX change.

Verified locally: `VERCEL_GIT_COMMIT_SHA=test123abcdef npm run build` produces a static HTML containing the inlined SHA.

## Test plan
- [x] `npm run build` clean
- [x] SHA inlined into static HTML when env var is set
- [ ] Vercel preview: SHA appears in footer, links to the deploy's commit
- [ ] Vercel preview: link target is reachable on the public repo