### PR TITLE
ci: add CodeQL + dependency review workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary
Adds two GitHub Actions for security baseline:

- **`.github/workflows/codeql.yml`** — CodeQL static analysis on every push to `master`, every PR, and weekly (Mondays 06:00 UTC). Uses the `security-and-quality` query suite for the JS/TS codebase.
- **`.github/workflows/dependency-review.yml`** — `actions/dependency-review-action@v4` on PRs. Fails on high+ severity vulnerabilities. Posts a PR comment summary on failure.

Both are free for public repos. No code or app behavior change.

## Test plan
- [x] YAML files parse clean
- [ ] CodeQL workflow runs successfully on this PR (initial run will take a few min)
- [ ] Dependency Review workflow runs successfully on this PR (no new deps, so should pass trivially)
- [ ] Subsequent PRs surface the new checks in their status list