### PR TITLE
chore: drop CDN Tailwind from page Heads

### DIFF
--- a/pages/app/index.js
+++ b/pages/app/index.js
@@ -10,7 +10,6 @@ export default class extends React.Component {
         <Head>
           <title>Super App | Home</title>
           <link href="/favicon.png" rel="shortcut icon" />
-          <script src="https://cdn.tailwindcss.com"></script>
         </Head>
 
         <Layout>

--- a/pages/app/login.js
+++ b/pages/app/login.js
@@ -51,7 +51,6 @@ export default class extends React.Component {
         <Head>
           <title>Super App | Log in with Email</title>
           <link href="/favicon.png" rel="shortcut icon" />
-          <script src="https://cdn.tailwindcss.com"></script>
         </Head>
 
         <LoginWithEmail

--- a/pages/app/settings.js
+++ b/pages/app/settings.js
@@ -48,7 +48,6 @@ export default class extends React.Component {
         <Head>
           <title>Super App | Admin Settings</title>
           <link href="/favicon.png" rel="shortcut icon" />
-          <script src="https://cdn.tailwindcss.com"></script>
         </Head>
 
         <Layout>

--- a/pages/app/sso.js
+++ b/pages/app/sso.js
@@ -47,7 +47,6 @@ export default class extends React.Component {
         <Head>
           <title>Super App | Log in with SSO</title>
           <link href="/favicon.png" rel="shortcut icon" />
-          <script src="https://cdn.tailwindcss.com"></script>
         </Head>
 
         <LoginWithSSO

--- a/pages/index.js
+++ b/pages/index.js
@@ -173,7 +173,6 @@ export default class extends React.Component {
         <Head>
           <title>Explore | WorkOS</title>
           <link href="https://workos.imgix.net/brand/v2/favicon@32x32.png" rel="shortcut icon" />
-          <script src="https://cdn.tailwindcss.com"></script>
         </Head>
 
         {this.renderHero()}


### PR DESCRIPTION
## Summary
Each page had a `<script src="https://cdn.tailwindcss.com">` tag in its `<Head>`, which produced a console warning on every page load (`"cdn.tailwindcss.com should not be used in production"`).

Tailwind is already wired via PostCSS (`postcss.config.js` + `tailwind.config.js`), so utility classes compile into a linked CSS file at build time. The CDN script was redundant.

5 files, one line removed each:
- `pages/index.js`
- `pages/app/index.js`
- `pages/app/login.js`
- `pages/app/settings.js`
- `pages/app/sso.js`

## Test plan
- [x] `npm run build` produces the same ~5.7 kB CSS bundle
- [x] `npm run dev`: all 5 routes return 200, `bg-blue-600` (and other utility classes) present in rendered HTML, zero `cdn.tailwindcss.com` references in any rendered page
- [x] Vercel preview: console no longer shows the production warning, pages still styled identically