### PR TITLE
fix: switch WorkOS SDK imports to named export

### DIFF
--- a/pages/api/admin-portal.js
+++ b/pages/api/admin-portal.js
@@ -1,4 +1,4 @@
-import WorkOS from '@workos-inc/node'
+import { WorkOS } from '@workos-inc/node'
 import baseURL from '../../lib/baseURL'
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY)

--- a/pages/api/callback.js
+++ b/pages/api/callback.js
@@ -1,4 +1,4 @@
-import WorkOS from '@workos-inc/node'
+import { WorkOS } from '@workos-inc/node'
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY)
 const clientID = process.env.WORKOS_CLIENT_ID

--- a/pages/api/magic-link.js
+++ b/pages/api/magic-link.js
@@ -1,4 +1,4 @@
-import WorkOS from '@workos-inc/node'
+import { WorkOS } from '@workos-inc/node'
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY)
 

--- a/pages/api/sso.js
+++ b/pages/api/sso.js
@@ -1,4 +1,4 @@
-import WorkOS from '@workos-inc/node'
+import { WorkOS } from '@workos-inc/node'
 import baseURL from '../../lib/baseURL'
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY)


### PR DESCRIPTION
## Summary
The `@workos-inc/node` v8 package has **no default export** — only named exports. Since the SDK was bumped to v8, the 4 API routes have been silently broken at runtime: `import WorkOS from '@workos-inc/node'` resolves to `undefined` under ESM, so `new WorkOS(...)` throws `"WorkOS is not a constructor"` on every API request.

```
$ node --input-type=module -e "import WorkOS from '@workos-inc/node'"
SyntaxError: The requested module '@workos-inc/node' does not provide an export named 'default'
```

The Vercel build doesn't catch this — Next bundles the import without exercising it. The bug only surfaces when an actual request hits the broken constructor (e.g. clicking any Settings tile, or going through the SSO/magic-link login flow). Confirmed via runtime logs.

## Fix
Switch all 4 API routes to the named import:

```js
import { WorkOS } from '@workos-inc/node'
```

Files: `pages/api/admin-portal.js`, `pages/api/sso.js`, `pages/api/callback.js`, `pages/api/magic-link.js`. 4 lines changed.

## Test plan
- [x] `npm run lint` clean (0 errors)
- [x] `npm run format:check` clean
- [x] `npm run build` clean
- [ ] Vercel preview: click any tile in `/app/settings` → should redirect to a valid Admin Portal URL (no 500)
- [ ] Vercel preview: `/app/login` Send Magic Link → no 500
- [ ] Vercel preview: `/app/sso` Login with SAML SSO → no 500