### PR TITLE
feat: add Datadog RUM

### DIFF
--- a/instrumentation-client.js
+++ b/instrumentation-client.js
@@ -1,0 +1,19 @@
+import { datadogRum } from '@datadog/browser-rum'
+import { nextjsPlugin } from '@datadog/browser-rum-nextjs'
+
+if (process.env.NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID) {
+  datadogRum.init({
+    applicationId: process.env.NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID,
+    clientToken: process.env.NEXT_PUBLIC_DATADOG_RUM_CLIENT_TOKEN,
+    site: process.env.NEXT_PUBLIC_DATADOG_RUM_SITE || 'datadoghq.com',
+    service: 'workos-explore',
+    env: process.env.NODE_ENV,
+    version: process.env.NEXT_PUBLIC_COMMIT_SHA || undefined,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 20,
+    trackResources: true,
+    trackUserInteractions: true,
+    trackLongTasks: true,
+    plugins: [nextjsPlugin()],
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@datadog/browser-rum": "^7.0.0",
+        "@datadog/browser-rum-nextjs": "^7.0.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@workos-inc/node": "^8.10.0",
@@ -42,6 +44,98 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-7.0.0.tgz",
+      "integrity": "sha512-msymElyeqNhpiWbQhSo7Dr9YJneZu7L60NOEclW1JCpvscM0Fyj940kz6/GcOU/5Azt7PAWv4ZCBhHwnmf0DcQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-7.0.0.tgz",
+      "integrity": "sha512-f+pckXe4L47Fic/NbRIfg1hEwhfenP2Y2iBhqodgwTD1MVSQK9bk7c/LRFTWRStqZcZ3S8zAh+U9ULyf13ZDwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-7.0.0.tgz",
+      "integrity": "sha512-+WMly+KBAts9vmBRY1sVMzuG2iTrkxplb4H6U0QBNHMmf3ZEkXy+hbl6DT4WF1ieMogLNaiLmidz1eUOWSH/zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.0.0"
+      }
+    },
+    "node_modules/@datadog/browser-rum-nextjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-nextjs/-/browser-rum-nextjs-7.0.0.tgz",
+      "integrity": "sha512-tXMAoH/uEy+wvlzAttObi317O86HgFrHq+0SaCqayM5Ppb6Uag4i1kfLgx/syQ8L4tjHWyghcFke7B0JOBzvcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0",
+        "@datadog/browser-rum-react": "7.0.0"
+      },
+      "peerDependencies": {
+        "next": ">=13.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-react": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-react/-/browser-rum-react-7.0.0.tgz",
+      "integrity": "sha512-jb5fTa5Hs42qv8bwkVXuZS3sk9i0jVswsBHxZLpWfZexkrtj7ourxpBaTK0aV22dFf0nIWqSphVvWuqfrmnB3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": ">=1.64.0 <2",
+        "react": "18 || 19",
+        "react-router": "6 || 7",
+        "react-router-dom": "6 || 7"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-rum": {
+          "optional": true
+        },
+        "@datadog/browser-rum-slim": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -3204,6 +3298,47 @@
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
+    },
+    "@datadog/browser-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-7.0.0.tgz",
+      "integrity": "sha512-msymElyeqNhpiWbQhSo7Dr9YJneZu7L60NOEclW1JCpvscM0Fyj940kz6/GcOU/5Azt7PAWv4ZCBhHwnmf0DcQ=="
+    },
+    "@datadog/browser-rum": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-7.0.0.tgz",
+      "integrity": "sha512-f+pckXe4L47Fic/NbRIfg1hEwhfenP2Y2iBhqodgwTD1MVSQK9bk7c/LRFTWRStqZcZ3S8zAh+U9ULyf13ZDwA==",
+      "requires": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-7.0.0.tgz",
+      "integrity": "sha512-+WMly+KBAts9vmBRY1sVMzuG2iTrkxplb4H6U0QBNHMmf3ZEkXy+hbl6DT4WF1ieMogLNaiLmidz1eUOWSH/zQ==",
+      "requires": {
+        "@datadog/browser-core": "7.0.0"
+      }
+    },
+    "@datadog/browser-rum-nextjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-nextjs/-/browser-rum-nextjs-7.0.0.tgz",
+      "integrity": "sha512-tXMAoH/uEy+wvlzAttObi317O86HgFrHq+0SaCqayM5Ppb6Uag4i1kfLgx/syQ8L4tjHWyghcFke7B0JOBzvcA==",
+      "requires": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0",
+        "@datadog/browser-rum-react": "7.0.0"
+      }
+    },
+    "@datadog/browser-rum-react": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-react/-/browser-rum-react-7.0.0.tgz",
+      "integrity": "sha512-jb5fTa5Hs42qv8bwkVXuZS3sk9i0jVswsBHxZLpWfZexkrtj7ourxpBaTK0aV22dFf0nIWqSphVvWuqfrmnB3g==",
+      "requires": {
+        "@datadog/browser-core": "7.0.0",
+        "@datadog/browser-rum-core": "7.0.0"
+      }
     },
     "@emnapi/runtime": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "format:check": "oxfmt --check"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^7.0.0",
+    "@datadog/browser-rum-nextjs": "^7.0.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@workos-inc/node": "^8.10.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,13 @@
 import '../styles/tailwind.css'
+import { DatadogPagesRouter } from '@datadog/browser-rum-nextjs'
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <DatadogPagesRouter />
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 export default MyApp


### PR DESCRIPTION
Wires up `@datadog/browser-rum` + the official `@datadog/browser-rum-nextjs` plugin:

- `instrumentation-client.js` calls `datadogRum.init()` with `nextjsPlugin()` so dynamic route segments are normalised in view names (e.g. `/users/[id]` instead of `/users/123`).
- `pages/_app.js` renders `<DatadogPagesRouter />` for automatic Pages Router transition tracking.

Init is gated on `NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID` being set, so local dev and forks without the env vars stay quiet.

**Required env vars** (set in deployment platform's project settings, scoped to Production + Preview):
- `NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID`
- `NEXT_PUBLIC_DATADOG_RUM_CLIENT_TOKEN`