### PR TITLE
refactor: replace .bind(this, intent) with arrow fn in Settings

### DIFF
--- a/components/Settings.js
+++ b/components/Settings.js
@@ -42,7 +42,7 @@ export default function Settings(props) {
 
         <div className="space-y-6 sm:px-6 lg:px-0 lg:col-span-9">
           <section aria-labelledby="payment-details-heading">
-            <form onSubmit={props.onSubmit.bind(this, 'sso')}>
+            <form onSubmit={(e) => props.onSubmit('sso', e)}>
               <div className="shadow sm:rounded-md sm:overflow-hidden">
                 <div className="bg-white py-6 px-4 sm:p-6">
                   <div>
@@ -70,7 +70,7 @@ export default function Settings(props) {
           </section>
 
           <section aria-labelledby="payment-details-heading">
-            <form onSubmit={props.onSubmit.bind(this, 'dsync')}>
+            <form onSubmit={(e) => props.onSubmit('dsync', e)}>
               <div className="shadow sm:rounded-md sm:overflow-hidden">
                 <div className="bg-white py-6 px-4 sm:p-6">
                   <div>
@@ -98,7 +98,7 @@ export default function Settings(props) {
           </section>
 
           <section aria-labelledby="payment-details-heading">
-            <form onSubmit={props.onSubmit.bind(this, 'audit_logs')}>
+            <form onSubmit={(e) => props.onSubmit('audit_logs', e)}>
               <div className="shadow sm:rounded-md sm:overflow-hidden">
                 <div className="bg-white py-6 px-4 sm:p-6">
                   <div>
@@ -126,7 +126,7 @@ export default function Settings(props) {
           </section>
 
           <section aria-labelledby="payment-details-heading">
-            <form onSubmit={props.onSubmit.bind(this, 'domain_verification')}>
+            <form onSubmit={(e) => props.onSubmit('domain_verification', e)}>
               <div className="shadow sm:rounded-md sm:overflow-hidden">
                 <div className="bg-white py-6 px-4 sm:p-6">
                   <div>


### PR DESCRIPTION
Clears the 4 `no-this-in-exported-function` oxlint warnings in `components/Settings.js`.

Settings is a function component; `props.onSubmit.bind(this, intent)` binds `this` to `undefined`. At runtime it works because the parent's `onSubmit` is itself bound to the parent class instance, so the inner bind's `this=undefined` is silently ignored. The arrow function form is clearer about what's actually happening — partial application of `intent`.

No runtime behaviour change. Lint warnings drop from 7 to 3.