### PR TITLE
chore: drop dead Your Profile menu items

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -27,7 +27,6 @@ const classNames = (...classes: (string | false | null | undefined)[]) =>
 export default function Layout(props: LayoutProps) {
   const userNavigation = [
     { name: 'Admin Settings', href: '/app/settings' },
-    { name: 'Your Profile', href: '#' },
     { name: 'Logout', href: '/app/login' },
   ]
 

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { Cog6ToothIcon, UserCircleIcon } from '@heroicons/react/24/outline'
+import { Cog6ToothIcon } from '@heroicons/react/24/outline'
 
 type Intent = 'sso' | 'dsync' | 'audit_logs' | 'domain_verification'
 
@@ -8,10 +8,7 @@ type SettingsProps = {
   message: string | null
 }
 
-const subNavigation = [
-  { name: 'Admin Settings', href: '#', icon: Cog6ToothIcon, current: true },
-  { name: 'Your Profile', href: '#', icon: UserCircleIcon, current: false },
-]
+const subNavigation = [{ name: 'Admin Settings', href: '#', icon: Cog6ToothIcon, current: true }]
 
 const classNames = (...classes: (string | false | null | undefined)[]) =>
   classes.filter(Boolean).join(' ')


### PR DESCRIPTION
Per git history, every "Your Profile" link has had `href: '#'` since the dashboard page first appeared in 2021-07-20. The placeholder was never wired up. Removed from `Layout.tsx` userNavigation and `Settings.tsx` subNavigation; `UserCircleIcon` dropped along with it. If AuthKit ends up exposing a profile view, wire it up fresh with a real route.